### PR TITLE
Select by url in AppPresentation 

### DIFF
--- a/components/AppPresentation/Alert.vue
+++ b/components/AppPresentation/Alert.vue
@@ -40,7 +40,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   },

--- a/components/AppPresentation/Dashboard.vue
+++ b/components/AppPresentation/Dashboard.vue
@@ -55,7 +55,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   },

--- a/components/AppPresentation/Description.vue
+++ b/components/AppPresentation/Description.vue
@@ -23,7 +23,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   },

--- a/components/AppPresentation/RecordingRule.vue
+++ b/components/AppPresentation/RecordingRule.vue
@@ -37,7 +37,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   }

--- a/components/AppPresentation/SetupGuide.vue
+++ b/components/AppPresentation/SetupGuide.vue
@@ -54,7 +54,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   },

--- a/components/AppPresentation/index.vue
+++ b/components/AppPresentation/index.vue
@@ -23,7 +23,7 @@ export default {
       required: true
     },
     resources: {
-      type: Object,
+      type: Array,
       required: true
     }
   }

--- a/pages/apps/_id/_version/index.vue
+++ b/pages/apps/_id/_version/index.vue
@@ -30,6 +30,7 @@
       </div>
       <b-tabs
         class="tabs"
+        v-model="tabIndex"
         fill
         justified
         content-class="tabs-content mt-3"
@@ -54,12 +55,34 @@ import AppPresentation from '@/components/AppPresentation'
 import { getCanonicalForApp } from '@/infrastructure/Canonical'
 
 export default {
+  data () {
+    return {
+      tabIndex: 0
+    }
+  },
   components: {
     AppPresentation
   },
   layout: 'content',
   async fetch ({ store, params }) {
     await store.dispatch('getAppAndResourcesByVersion', { id: params.id, version: params.version })
+  },
+  created () {
+    if (!this.$root._route.hash) {
+      return
+    }
+
+    const visibleTab = this.$root._route.hash.replace('#', '')
+    const findTabIndex = (resources, candidate) => {
+      for (let index = 0; index < resources.length; index++) {
+        if (resources[index].kind === candidate) {
+          return index
+        }
+      }
+      return 0
+    }
+
+    this.tabIndex = findTabIndex(this.appResources, visibleTab)
   },
   computed: {
     ...mapState({


### PR DESCRIPTION
This change allows urls like `/apps/aws-rds#SetupGuide` or `apps/kubernetes-control-plane/1.14.0#Alert`so the page loads with the desired tab open (e.g. this would be handy when linking for the blog to the setup guide)

I also changed the `resources` type from Object to Array, because I was getting a console error.

Thanks!!

cc: @daviddetorres @Dlorite 