### PR TITLE
Add-new-install-instructions

### DIFF
--- a/components/AppPresentation/Alert.vue
+++ b/components/AppPresentation/Alert.vue
@@ -12,7 +12,7 @@
       Import into {{ alert.kind }}
     </Download>
     <H2>Alert details</H2>
-    To install these alerts in Sysdig Monitor, consult the <a target="_blank" href="https://docs.sysdig.com/en/promql-alerts.html#UUID-7b0f1744-88a0-a4dc-ac88-0bd70008bd18_UUID-9d9d7ee9-2898-a9aa-ea9b-4ab2328f3bf0">following documentation</a>.
+    <i>These alerts are included in the <a target="_blank" href="https://docs.sysdig.com/en/docs/sysdig-monitor/alerts/alerts-library/">Alert Library</a> of Sysdig Monitor. To install alerts in Prometheus format, consult the <a target="_blank" href="https://docs.sysdig.com/en/promql-alerts.html#UUID-7b0f1744-88a0-a4dc-ac88-0bd70008bd18_UUID-9d9d7ee9-2898-a9aa-ea9b-4ab2328f3bf0">following documentation</a></i>.
     <prism
       v-for="config in kindPrometheus"
       :key="`${config.name}`"

--- a/components/AppPresentation/SetupGuide.vue
+++ b/components/AppPresentation/SetupGuide.vue
@@ -66,6 +66,8 @@ export default {
     installInstructions () {
       let instructions = ''
       instructions += '# Installing dashboards and alerts in Sysdig Monitor:\n'
+      instructions += '<i>Note: This instructions are only for on-prem customers and legacy environments. All these dashboards and alerts are available out-of-the-box in Sysdig monitor platform. '
+      instructions += 'Here is the list of <a target="_blank" href="https://docs.sysdig.com/en/docs/sysdig-monitor/dashboards/dashboard-templates/">all the dashboards included in the platform</a>.</i>\n\n'
       instructions += 'Run this command using your API-TOKEN (-u argument is optional):\n'
       instructions += '```bash\n'
       instructions += 'docker  run -it --rm \\\n'


### PR DESCRIPTION
Add note that no install is needed for dashbaords and alerts.
Also added links to official docs.

